### PR TITLE
Build: Rewrite format-suggest action to more be more secure

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -1,20 +1,7 @@
 # Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
 
 on:
-  # Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
-  # privileges, otherwise we can't set `pull-requests: write` when the pull
-  # request comes from a fork, which is our main use case (external contributors).
-  #
-  # `pull_request_target` runs in the context of the target branch (`main`, usually),
-  # rather than in the context of the pull request like `pull_request` does. Due
-  # to this, we must explicitly checkout `ref: ${{ github.event.pull_request.head.sha }}`.
-  # This is typically frowned upon by GitHub, as it exposes you to potentially running
-  # untrusted code in a context where you have elevated privileges, but they explicitly
-  # call out the use case of reformatting and committing back / commenting on the PR
-  # as a situation that should be safe (because we aren't actually running the untrusted
-  # code, we are just treating it as passive data).
-  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-  pull_request_target:
+  pull_request:
 
 name: format-suggest.yaml
 
@@ -28,9 +15,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v6
 
       - name: Install
         uses: posit-dev/setup-air@v1


### PR DESCRIPTION
Your commits explain the `what` and `where` you made changes in the code. Your commit messages explain `why` you made the commits. You do not need to reiterate this. This PR is meant to address the big picture, `Why`

### Justification

I've rewritten some aspects of Posit's `format-suggest` workflow to make the action more secure. To apply the action to PRs from forks, Posit uses an approach that can run untrusted code. This updated workflow replaces that approach with one that is more secure for projects that rarely use forks for collaboration.

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply) 

### Checklist/Reminders

Put an `x` in the boxes that apply

- [ ] I have updated relevant documentation? (run `pkgdown::build_site()` to check)
- [ ] I have created unit tests and run `devtools::test()` to ensure all unit tests pass locally?
- [ ] I have run `devtools::check()` to ensure package builds locally?
- [x] I have followed the proposed [CONTRIBUTING](../blob/main/CONTRIBUTING.md) guideline?
 
### Further comments

This is a trivial change that I was able to make directly from Github. I did not open the code base in an IDE; therefore, I did not run any of the recommended checks and tests listed above. This pull request and its contents are the only documentation for this change.

### Reviewer instructions:
Please review the commit and changed file. If you want to maintain this workflow's capacity to apply to forks, **do not** accept this change. Please reach out if you'd like to discuss considerations for either approach.

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.
