### PR TITLE
build(#68): allows usethis to install on VM

### DIFF
--- a/.github/workflows/stocksmartapi.yml
+++ b/.github/workflows/stocksmartapi.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install command line packages
         run: |
           sudo apt update
-          sudo apt-get install libcurl4-openssl-dev libgit2-dev
+          sudo apt-get install r-base-dev libuv1-dev libcurl4-openssl-dev libgit2-dev
 #          sudo apt-get install  libgdal-dev libcurl4-gnutls-dev libgit2-dev libudunits2-dev libharfbuzz-dev libfribidi-dev
         shell: bash
 


### PR DESCRIPTION
Your commits explain the `what` and `where` you made changes in the code. Your commit messages explain `why` you made the commits. You do not need to reiterate this. This PR is meant to address the big picture, `Why`

### Justification

`usethis` requires additional Linux binaries on the VM before it can be installed.

fixes #68

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply) 

### Reviewer instructions:

None. The running workflow will be the test

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.
